### PR TITLE
enable x86_64 on windows and bump version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,8 +25,7 @@ case `uname` in
         clang --version
         llvm-as --version
         llvm-ar --version
-        # TODO: change intel64->x86_64 when ARG_MAX issue is fixed.
-        ./configure --disable-shared --prefix=$PREFIX/Library --enable-cblas --enable-threading=pthreads intel64
+        ./configure --disable-shared --prefix=$PREFIX/Library --enable-cblas --enable-threading=pthreads --enable-arg-max-hack x86_64
         make CPICFLAGS= LIBPTHREAD=-lpthreads AR=llvm-ar LIBM= -j${CPU_COUNT}
         make install
         make check CPICFLAGS= LIBPTHREAD=-lpthreads AR=llvm-ar LIBM= -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "blis" %}
-{% set version = "0.3.3.dev0" %}
+{% set version = "0.3.3.dev1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/flame/blis/archive/e32b2ef983ea1c3521dd3821116c0078690f125e.tar.gz
-  sha256: 673668858d7a5bb49b9f3a14f120e8c3ab9a134da9906b57aebca222ad1e4232
+  url: https://github.com/flame/blis/archive/331694e52414c0cd50048daf880a9ace9e29b94a.tar.gz
+  sha256: e4e2b2d5208aad711446fa25ef04ace0b181a574a7aa0ca4dc9706244015907d
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
